### PR TITLE
Set correct initial values for different field types

### DIFF
--- a/src/cms/components/form/FormFieldBuilder.js
+++ b/src/cms/components/form/FormFieldBuilder.js
@@ -33,9 +33,9 @@ const FormFieldBuilder = ({
         <FieldArray
           component={C.FieldList}
           fieldNames={field.fields}
-          name={field.name}
+          name={field._name}
           props={{
-            name: field.name,
+            name: field._name,
           }}
         />
       );
@@ -91,14 +91,14 @@ const FormFieldBuilder = ({
   return (
     /* eslint-disable react/jsx-one-expression-per-line */
     <div className='form__element'>
-      <label className='form__label' htmlFor={`${prefix}${field.name}`}>{field.label}:</label>
+      <label className='form__label' htmlFor={`${prefix}${field._name}`}>{field.label}:</label>
       <Field
         {...field}
         className={`form__field ${fieldClassName}`}
         component={component}
         disabled={isIndexPathField}
-        id={field.name}
-        name={`${prefix}${field.name}`}
+        id={field._name}
+        name={`${prefix}${field._name}`}
         options={options}
         placeholder={isIndexPathField ? '' : field.placeholder}
         type={type}

--- a/src/cms/helpers/appendEmptyField.js
+++ b/src/cms/helpers/appendEmptyField.js
@@ -1,7 +1,7 @@
 import * as k from '%/constants/keywords';
 import { getFieldWithName } from '%/selectors';
 
-const appendEmptyField = (field, parent) => {
+const appendEmptyField = (field, parent, state) => {
   /* eslint-disable no-param-reassign */
   switch (field.type) {
     case k.LIST: {
@@ -11,8 +11,8 @@ const appendEmptyField = (field, parent) => {
       for (let i = 0; i < minItems; i += 1) {
         const newListItem = {};
         fieldNames.forEach(fieldName => {
-          const nestedField = getFieldWithName(fieldName);
-          appendEmptyField(nestedField, newListItem);
+          const nestedField = getFieldWithName(fieldName)(state);
+          appendEmptyField(nestedField, newListItem, state);
         });
         list.push(newListItem);
       }

--- a/src/cms/helpers/appendEmptyField.js
+++ b/src/cms/helpers/appendEmptyField.js
@@ -1,0 +1,28 @@
+import * as k from '%/constants/keywords';
+
+export default (field, parent) => {
+  switch (field.type) {
+    case k.LIST: {
+      const { fields: itemFieldNames, minItems } = field;
+      parent[field._name] = [];
+
+      for (let i = 0; i < minItems; i += 1) {
+        const newItem = {};
+        itemFieldNames.forEach(fieldName => newItem[fieldName] = '');
+        parent[field._name].push(newItem);
+      }
+      break;
+    }
+
+    case k.BOOLEAN:
+      parent[field._name] = false;
+      break;
+
+    case k.TAGS:
+      parent[field._name] = [];
+      break;
+
+    default:
+      parent[field._name] = '';
+  }
+};

--- a/src/cms/helpers/appendEmptyField.js
+++ b/src/cms/helpers/appendEmptyField.js
@@ -1,16 +1,22 @@
 import * as k from '%/constants/keywords';
+import { getFieldWithName } from '%/selectors';
 
-export default (field, parent) => {
+const appendEmptyField = (field, parent) => {
+  /* eslint-disable no-param-reassign */
   switch (field.type) {
     case k.LIST: {
-      const { fields: itemFieldNames, minItems } = field;
-      parent[field._name] = [];
+      const { fields: fieldNames, minItems } = field;
+      const list = [];
 
       for (let i = 0; i < minItems; i += 1) {
-        const newItem = {};
-        itemFieldNames.forEach(fieldName => newItem[fieldName] = '');
-        parent[field._name].push(newItem);
+        const newListItem = {};
+        fieldNames.forEach(fieldName => {
+          const nestedField = getFieldWithName(fieldName);
+          appendEmptyField(nestedField, newListItem);
+        });
+        list.push(newListItem);
       }
+      parent[field._name] = list;
       break;
     }
 
@@ -25,4 +31,7 @@ export default (field, parent) => {
     default:
       parent[field._name] = '';
   }
+  /* eslint-enable */
 };
+
+export default appendEmptyField;

--- a/src/cms/helpers/appendEmptyField.test.js
+++ b/src/cms/helpers/appendEmptyField.test.js
@@ -11,7 +11,7 @@ describe('helpers/appendEmptyField', () => {
           type: 'string',
         },
       },
-    }, 
+    },
   };
 
   beforeEach(() => {

--- a/src/cms/helpers/appendEmptyField.test.js
+++ b/src/cms/helpers/appendEmptyField.test.js
@@ -1,0 +1,44 @@
+import * as k from '%/constants/keywords';
+import appendEmptyField from './appendEmptyField';
+
+describe('helpers/appendEmptyField', () => {
+  let field, parent;
+
+  beforeEach(() => {
+    parent = {};
+    field = {
+      _name: 'test',
+    };
+  });
+
+  it('should append a field with value: "" as default', () => {
+    appendEmptyField(field, parent);
+
+    expect(parent).toHaveProperty('test', '');
+  });
+
+  it('should append a field with value: false for booleans', () => {
+    field.type = k.BOOLEAN;
+    appendEmptyField(field, parent);
+
+    expect(parent).toHaveProperty('test', false);
+  });
+
+  it('should append a field with value: [] for tags', () => {
+    field.type = k.TAGS;
+    appendEmptyField(field, parent);
+
+    expect(parent).toHaveProperty('test', []);
+  });
+
+  it('should append a list of nested fields for lists', () => {
+    field.type = k.LIST;
+    field.fields = ['nested-test'];
+    field.minItems = 1;
+    appendEmptyField(field, parent);
+
+    expect(parent).toHaveProperty('test');
+    expect(parent.test[0]).toHaveProperty('nested-test', '');
+  });
+
+});

--- a/src/cms/helpers/appendEmptyField.test.js
+++ b/src/cms/helpers/appendEmptyField.test.js
@@ -4,6 +4,16 @@ import appendEmptyField from './appendEmptyField';
 describe('helpers/appendEmptyField', () => {
   let field, parent;
 
+  const mockState = {
+    structure: {
+      fields: {
+        nestedTest: {
+          type: 'string',
+        },
+      },
+    }, 
+  };
+
   beforeEach(() => {
     parent = {};
     field = {
@@ -12,33 +22,33 @@ describe('helpers/appendEmptyField', () => {
   });
 
   it('should append a field with value: "" as default', () => {
-    appendEmptyField(field, parent);
+    appendEmptyField(field, parent, mockState);
 
     expect(parent).toHaveProperty('test', '');
   });
 
   it('should append a field with value: false for booleans', () => {
     field.type = k.BOOLEAN;
-    appendEmptyField(field, parent);
+    appendEmptyField(field, parent, mockState);
 
     expect(parent).toHaveProperty('test', false);
   });
 
   it('should append a field with value: [] for tags', () => {
     field.type = k.TAGS;
-    appendEmptyField(field, parent);
+    appendEmptyField(field, parent, mockState);
 
     expect(parent).toHaveProperty('test', []);
   });
 
   it('should append a list of nested fields for lists', () => {
     field.type = k.LIST;
-    field.fields = ['nested-test'];
+    field.fields = ['nestedTest'];
     field.minItems = 1;
-    appendEmptyField(field, parent);
+    appendEmptyField(field, parent, mockState);
 
     expect(parent).toHaveProperty('test');
-    expect(parent.test[0]).toHaveProperty('nested-test', '');
+    expect(parent.test[0]).toHaveProperty('nestedTest', '');
   });
 
 });

--- a/src/cms/middleware/pages.js
+++ b/src/cms/middleware/pages.js
@@ -3,6 +3,7 @@ import * as t from '%/actions/types';
 import * as k from '%/constants/keywords';
 import * as selectors from '%/selectors';
 import getRandomString from '%/helpers/getRandomString';
+import appendEmptyField from '%/helpers/appendEmptyField';
 
 // eslint-disable-next-line consistent-return
 export default ({ dispatch, getState }) => next => action => {
@@ -29,21 +30,7 @@ export default ({ dispatch, getState }) => next => action => {
     };
 
     const fields = selectors.getFieldsForPageType(_type)(getState());
-    fields.forEach(field => {
-      if (field.type === k.LIST) {
-        const { fields: itemFieldNames, minItems } = field;
-        newPage[field._name] = [];
-
-        for (let i = 0; i < minItems; i += 1) {
-          const newItem = {};
-          itemFieldNames.forEach(fieldName => newItem[fieldName] = '');
-          newPage[field._name].push(newItem);
-        }
-
-      } else {
-        newPage[field._name] = '';
-      }
-    });
+    fields.forEach(field => appendEmptyField(field, newPage));
 
     payload.page = newPage;
     next(action);

--- a/src/cms/middleware/pages.js
+++ b/src/cms/middleware/pages.js
@@ -30,7 +30,7 @@ export default ({ dispatch, getState }) => next => action => {
     };
 
     const fields = selectors.getFieldsForPageType(_type)(getState());
-    fields.forEach(field => appendEmptyField(field, newPage));
+    fields.forEach(field => appendEmptyField(field, newPage, getState()));
 
     payload.page = newPage;
     next(action);

--- a/src/cms/middleware/sections.js
+++ b/src/cms/middleware/sections.js
@@ -28,7 +28,7 @@ export default ({ dispatch, getState }) => next => action => {
     };
 
     const fields = selectors.getFieldsForSectionType(_type)(getState());
-    fields.forEach(field => appendEmptyField(field, newSection));
+    fields.forEach(field => appendEmptyField(field, newSection, getState()));
 
     payload.section = newSection;
   }

--- a/src/cms/middleware/sections.js
+++ b/src/cms/middleware/sections.js
@@ -1,8 +1,9 @@
 import * as actions from '%/actions';
 import * as t from '%/actions/types';
 import * as k from '%/constants/keywords';
-import getRandomString from '%/helpers/getRandomString';
 import * as selectors from '%/selectors';
+import getRandomString from '%/helpers/getRandomString';
+import appendEmptyField from '%/helpers/appendEmptyField';
 
 // eslint-disable-next-line consistent-return
 export default ({ dispatch, getState }) => next => action => {
@@ -27,21 +28,7 @@ export default ({ dispatch, getState }) => next => action => {
     };
 
     const fields = selectors.getFieldsForSectionType(_type)(getState());
-    fields.forEach(field => {
-      if (field.type === k.LIST) {
-        const { fields: itemFieldNames, minItems } = field;
-        newSection[field._name] = [];
-
-        for (let i = 0; i < minItems; i += 1) {
-          const newItem = {};
-          itemFieldNames.forEach(fieldName => newItem[fieldName] = '');
-          newSection[field._name].push(newItem);
-        }
-
-      } else {
-        newSection[field._name] = '';
-      }
-    });
+    fields.forEach(field => appendEmptyField(field, newSection));
 
     payload.section = newSection;
   }

--- a/src/cms/selectors/fields.js
+++ b/src/cms/selectors/fields.js
@@ -7,7 +7,7 @@ export const getFieldWithName = fieldName => createSelector(
   [
     s.getFields,
   ],
-  fields => ({ ...fields[fieldName], name: fieldName })
+  fields => ({ ...fields[fieldName], _name: fieldName })
 );
 
 export const getFieldsForPageType = pageType => createSelector(

--- a/src/cms/selectors/fields.test.js
+++ b/src/cms/selectors/fields.test.js
@@ -15,7 +15,7 @@ describe('selectors/form', () => {
     it('should return the field with an added "name" parameter', () => {
       const result = selectors.getFieldWithName('title')(mockState);
 
-      expect(result).toHaveProperty('name', 'title');
+      expect(result).toHaveProperty('_name', 'title');
       expect(result).toHaveProperty('placeholder', 'Your title');
     });
   });


### PR DESCRIPTION
- sets initial value for `boolean` to `false`
- sets initial value for `tags` to `[]`
- sets initial value for fields within `field lists` to their respective initial values (instead of just strings)